### PR TITLE
Add fct voltage series

### DIFF
--- a/models/marts/fct_voltage_series.sql
+++ b/models/marts/fct_voltage_series.sql
@@ -1,13 +1,21 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
 
 -- import models
 with fct_time_series as (
     select * from {{ ref('fct_time_series') }}
 ),
-
+-- rows of voltage (2.000, 2.001, 2.002, ..., 3.499, 3.500)
 int_voltage_range as (
     select * from {{ ref('int_voltage_range') }}
 ),
 
+-- start the model
+
+-- get discharge data only
 discharge_time_series as (
     select
         file_name,
@@ -17,56 +25,95 @@ discharge_time_series as (
 
     from fct_time_series
     where step_type = 'discharge'
+    --and cycle_index = 100 -- sample for testing purpose
+    --and file_name = 'cycler_data/2018-04-12_batch8_CH38.csv' -- sample for testing purpose
 ),
 
-distinct_file_name_cycle_index as (
-    select 
-        file_name,
-        cycle_index
-    from discharge_time_series
-    qualify row_number() over (partition by file_name, cycle_index order by file_name, cycle_index) = 1
-),
-
--- for each (file_name, cycle_index) pair, create voltage range from 2V to 3.5V
-create_voltage_grid as (
+get_each_cycle_voltage_range as (
     select
         file_name,
         cycle_index,
-        voltage
-    from distinct_file_name_cycle_index
+        min(voltage) as voltage_min,
+        max(voltage) as voltage_max
+
+    from discharge_time_series
+    group by file_name, cycle_index
+),
+
+each_cycle_voltage_spine as (
+    select
+        get_each_cycle_voltage_range.file_name,
+        get_each_cycle_voltage_range.cycle_index,
+        int_voltage_range.voltage
+
+    from get_each_cycle_voltage_range
     cross join int_voltage_range
-    order by file_name, cycle_index, voltage
+
+    where int_voltage_range.voltage > get_each_cycle_voltage_range.voltage_min
+    and int_voltage_range.voltage < get_each_cycle_voltage_range.voltage_max
 ),
 
-concat_voltage_grid as (
-    select
-        file_name,
-        cycle_index,
-        voltage,
-        null as discharge_capacity
-    from create_voltage_grid
-    union all
-    select
-        file_name,
-        cycle_index,
-        voltage,
-        discharge_capacity
-    from discharge_time_series
-),
-
--- interpolate discharge_capacity by voltage
-interp_discharge_capacity as (
+time_series_union_voltage_spine as (
     select
         file_name,
         cycle_index,
         voltage,
         discharge_capacity,
-        discharge_capacity_interp
+        'real' as voltage_source
+    from discharge_time_series
+    
+    union all
+    
+    select
+        file_name,
+        cycle_index,
+        voltage,
+        null as discharge_capacity,
+        'interpolate' as voltage_source
+    from each_cycle_voltage_spine
+),
 
-)
+add_interpolate_feature as (
+    select
+        file_name,
+        cycle_index,
+        voltage,
+        discharge_capacity,
+        voltage_source,
+        first_value(discharge_capacity) ignore nulls over (partition by file_name, cycle_index order by voltage asc rows BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) as discharge_capacity_next,
+        first_value(discharge_capacity) ignore nulls over (partition by file_name, cycle_index order by voltage desc rows BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) as discharge_capacity_previous,
+        first_value(case when discharge_capacity is not null then voltage else null end) ignore nulls over (partition by file_name, cycle_index order by voltage asc rows BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) as voltage_next,
+        first_value(case when discharge_capacity is not null then voltage else null end) ignore nulls over (partition by file_name, cycle_index order by voltage desc rows BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) as voltage_previous
+
+    from time_series_union_voltage_spine
+),
+
+interpolate_discharge_capacity as (
+    select
+        file_name,
+        cycle_index,
+        voltage,
+        voltage_source,
+        case 
+            when voltage_next = voltage_previous then discharge_capacity
+            else (discharge_capacity_previous * (voltage_next - voltage) + discharge_capacity_next * (voltage - voltage_previous)) / (voltage_next - voltage_previous) 
+        end as discharge_capacity_interpolate
+    from add_interpolate_feature
+),
+
+remove_real_data as (
+    select
+        file_name,
+        cycle_index,
+        voltage,
+        discharge_capacity_interpolate
+    from interpolate_discharge_capacity
+    where voltage_source = 'interpolate'
+),
 
 final as (
-    select * from concat_voltage_grid
+    select * 
+    from remove_real_data
 )
 
-select * from final limit 1000
+select * from final

--- a/models/marts/fct_voltage_series.sql
+++ b/models/marts/fct_voltage_series.sql
@@ -106,7 +106,6 @@ remove_real_data as (
         file_name,
         cycle_index,
         voltage,
-        voltage_source,
         discharge_capacity_interpolate as discharge_capacity
     from interpolate_discharge_capacity
     where voltage_source = 'interpolate'

--- a/models/marts/fct_voltage_series.sql
+++ b/models/marts/fct_voltage_series.sql
@@ -1,0 +1,72 @@
+
+-- import models
+with fct_time_series as (
+    select * from {{ ref('fct_time_series') }}
+),
+
+int_voltage_range as (
+    select * from {{ ref('int_voltage_range') }}
+),
+
+discharge_time_series as (
+    select
+        file_name,
+        cycle_index,
+        voltage,
+        discharge_capacity
+
+    from fct_time_series
+    where step_type = 'discharge'
+),
+
+distinct_file_name_cycle_index as (
+    select 
+        file_name,
+        cycle_index
+    from discharge_time_series
+    qualify row_number() over (partition by file_name, cycle_index order by file_name, cycle_index) = 1
+),
+
+-- for each (file_name, cycle_index) pair, create voltage range from 2V to 3.5V
+create_voltage_grid as (
+    select
+        file_name,
+        cycle_index,
+        voltage
+    from distinct_file_name_cycle_index
+    cross join int_voltage_range
+    order by file_name, cycle_index, voltage
+),
+
+concat_voltage_grid as (
+    select
+        file_name,
+        cycle_index,
+        voltage,
+        null as discharge_capacity
+    from create_voltage_grid
+    union all
+    select
+        file_name,
+        cycle_index,
+        voltage,
+        discharge_capacity
+    from discharge_time_series
+),
+
+-- interpolate discharge_capacity by voltage
+interp_discharge_capacity as (
+    select
+        file_name,
+        cycle_index,
+        voltage,
+        discharge_capacity,
+        discharge_capacity_interp
+
+)
+
+final as (
+    select * from concat_voltage_grid
+)
+
+select * from final limit 1000

--- a/models/marts/fct_voltage_series.sql
+++ b/models/marts/fct_voltage_series.sql
@@ -106,7 +106,8 @@ remove_real_data as (
         file_name,
         cycle_index,
         voltage,
-        discharge_capacity_interpolate
+        voltage_source,
+        discharge_capacity_interpolate as discharge_capacity
     from interpolate_discharge_capacity
     where voltage_source = 'interpolate'
 ),

--- a/models/marts/fct_voltage_series.yml
+++ b/models/marts/fct_voltage_series.yml
@@ -1,0 +1,32 @@
+version: 2
+
+models:
+  - name: fct_voltage_series
+    description: >
+      Cell discharge voltage curve for cycle-to-cycle evolution of Q(V), the discharge voltage curve as a function of voltage for a given cycle. 
+      Interpolate the original time series data to identical voltage range for every cycle. (2.000, 2.001, 2.002, ..., 3.499, 3.500V)
+      
+    columns:
+      - name: file_name
+        description: File name of data source
+        tests:
+          - not_null
+
+      - name: cycle_index
+        description: Test cycle index
+        tests:
+          - not_null
+
+      - name: voltage
+        description: Voltage range for every cycle from (2.000, 2.001, 2.002, ..., 3.499, 3.500V)
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 2.000
+              max_value: 3.500
+
+      - name: discharge_capacity
+        description: Discharge capacity interpolate to identical voltage range
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0.000
+              max_value: 1.500

--- a/models/staging/int_voltage_range.sql
+++ b/models/staging/int_voltage_range.sql
@@ -1,0 +1,2 @@
+select 2.0 + seq4()/1000 as voltage
+from table(generator(rowcount => 1501)) 

--- a/models/staging/int_voltage_range.sql
+++ b/models/staging/int_voltage_range.sql
@@ -1,2 +1,2 @@
 select 2.0 + seq4()/1000 as voltage
-from table(generator(rowcount => 1501)) 
+from table(generator(rowcount => 1500)) 

--- a/models/staging/int_voltage_range.sql
+++ b/models/staging/int_voltage_range.sql
@@ -3,7 +3,7 @@
         materialized='table'
     )
 }}
-
+-- generate row of data starting from 2.000, 2.001, 2.002 to 3.500
 select 
     2.0 + seq4()/1000 as voltage
 from table(generator(rowcount => 1500)) 

--- a/models/staging/int_voltage_range.sql
+++ b/models/staging/int_voltage_range.sql
@@ -1,2 +1,9 @@
-select 2.0 + seq4()/1000 as voltage
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+select 
+    2.0 + seq4()/1000 as voltage
 from table(generator(rowcount => 1500)) 


### PR DESCRIPTION
## Description & Motivation
Create model for cell discharge voltage curve for cycle-to-cycle evolution of Q(V), the discharge voltage curve as a function of voltage for a given cycle. Interpolate the original time series data to an identical voltage ranges for every cycle. (2.000, 2.001, 2.002, ..., 3.499, 3.500V)

File changes in this pull request are:
- models/marts/fct_voltage_series.sql: a model for interpolating discharge voltage curve 
- models/marts/fct_voltage_series.yml: document
- models/staging/int_voltage_range.sql: a model for generating voltage range

## To-do before the merge
None

## Screenshots:
<img width="1367" alt="image" src="https://user-images.githubusercontent.com/6430724/183240799-8401ceff-69d9-4efe-bf51-f6ef5ef0ac7b.png">

## Validation of models:

`dbt test --select +fct_voltage_series`
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/6430724/183241227-fad2a028-e835-49c8-9207-5387ef6e0aaf.png">

`dbt_utils_accepted_range_fct_voltage_series_discharge_capacity__1_5__0_0` failed.

<img width="1146" alt="image" src="https://user-images.githubusercontent.com/6430724/183241375-e60c3cdb-2115-47b0-83c6-1a55e950329e.png">

Discharge capacity has a large value at the beginning and end of the cycle. 
Record this issue https://github.com/allenwangs/battery_cell/issues/7

### plotting 
Difference of the discharge capacity curves as a function of voltage between the 100th and 10th cycles
<img width="818" alt="image" src="https://user-images.githubusercontent.com/6430724/183241596-f4fe2e85-69b3-47bc-83ac-b3da067e9731.png">


## Changes to existing models:
None

## Checklist:
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] My SQL follows the style guide.
- [x] I have materialized my models appropriately.
- [x] I have added appropriate tests and documentation to any new models.

